### PR TITLE
Fix `@nextcloud/l10n/gettext` import

### DIFF
--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -1,4 +1,4 @@
-import { getGettextBuilder } from '@nextcloud/l10n/dist/gettext.js'
+import { getGettextBuilder } from '@nextcloud/l10n/gettext'
 
 const gtBuilder = getGettextBuilder()
 	.detectLocale()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "esnext",
     "useDefineForClassFields": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "jsx": "preserve",
     "resolveJsonModule": true,


### PR DESCRIPTION
### Fix tsconfig moduleResolution

`moduleResolution: node` is for `node v10` .. `node v15` (while engine is `node v20`) and doesn't support `package.json` fields `imports` and `exports`

https://www.typescriptlang.org/tsconfig#moduleResolution

### Fix l10n import

`@nextcloud/l10n/dist/gettext.js` is not the correct import according to its `exports`: https://github.com/nextcloud-libraries/nextcloud-l10n/blob/609525946917bb3613773415966e2536484e66fe/package.json#L7-L18

It results in an incorrect bundle where `import { getGettextBuilder } from '@nextcloud/l10n/dist/gettext.js'` doesn't work on build

### How to test

Try to update to `@nextcloud/vue@8` which uses `@nextcloud/l10n@2`, and build the server.
For example, here: https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/605