### PR TITLE
release: v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## 4.1.0 - 2023-10-09
+
+### Added
+
+- `isPasswordConfirmationRequired(): boolean` function to replace deprecated `OC.PasswordConfirmation.requiresPasswordConfirmation()`
+
+### Fixed
+
+- Fix compatibility with `@nextcloud/l10n@^2`
+
+### Changed
+
+- Add `package.json/exports`
+- Move to `nextcloud-libraries` organization
+- Add ESLint for linting files
+- Dependency updates
+
 ## 4.0.4 - 2023-02-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Promise-based password confirmation for Nextcloud.
 
 This library exports a function that displays a password confirmation dialog when called and returns a promise. This makes it easier to integrate with other asynchronous operations.
 
+## Versions compatibility
+
+Nextcloud   | @nextcloud/vue | @nextcloud/password-confirmation
+------------|----------------|---------------------------------
+28.x        | 8.x            | 5.x
+25.x - 27.x | 7.x            | 2.x - 4.x
+< 25.x      | -              | 1.x
+
+
 ## Installation
 ```sh
 npm add @nextcloud/password-confirmation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/password-confirmation",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/password-confirmation",
-      "version": "4.0.4",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@nextcloud/axios": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/password-confirmation",
-  "version": "4.0.4",
+  "version": "4.1.0",
   "description": "Password confirmation for Nextcloud",
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
⚠️ Waiting for backports:
1. https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/616
2. https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/617

## 4.1.0 - 2023-10-09

### Added

- `isPasswordConfirmationRequired(): boolean` function to replace deprecated `OC.PasswordConfirmation.requiresPasswordConfirmation()`

### Fixed

- Fix compatibility with `@nextcloud/l10n@^2`

### Changed

- Add `package.json/exports`
- Move to `nextcloud-libraries` organization
- Add ESLint for linting files
- Dependency updates