### PR TITLE
Fix/do not mount to hidden modal

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,10 @@ export const confirmPassword = (): Promise<void> => {
 	const mountPoint = document.createElement('div')
 	mountPoint.setAttribute('id', DIALOG_ID)
 
-	const modals = document.querySelectorAll(`.${MODAL_CLASS}`)
+	const modals = Array.from(document.querySelectorAll(`.${MODAL_CLASS}`) as NodeListOf<HTMLElement>)
+		// Filter out hidden modals
+		.filter((modal) => modal.style.display !== 'none')
+
 	const isModalMounted = Boolean(modals.length)
 
 	if (isModalMounted) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -53,7 +53,7 @@ export const confirmPassword = (): Promise<void> => {
 		const previousModal = modals[modals.length - 1]
 		previousModal.prepend(mountPoint)
 	} else {
-		document.body.prepend(mountPoint)
+		document.body.appendChild(mountPoint)
 	}
 
 	const DialogClass = Vue.extend(PasswordDialogVue)


### PR DESCRIPTION
See details in: https://github.com/nextcloud/server/issues/41760#issuecomment-1827815550

- Do not mount to hidden modal
- Mount dialog to the end of body by default
  So it mounts the same as original NcModal.
  And make sure it overflows any siblings in body.

I'm not a fan of the current workaround, but IMO the best alternative is to provide some centralized method to work between popover components.