### PR TITLE
build: fix dev and watch build by specifying CSS chunk path

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "dev": "vite build --mode development",
     "watch": "vite build --mode development --watch",
-    "build": "vite build --mode production && mv dist/main.css dist/style.css",
+    "build": "vite build --mode production",
     "l10n:extract": "node build/extract-l10n.mjs",
     "lint": "eslint --ignore-pattern dist/**/* .",
     "lint:fix": "eslint --fix --ignore-pattern dist/**/* ."

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -20,6 +20,8 @@ export default createLibConfig({
 	index: resolve(__dirname, 'src/main.ts'),
 }, {
 	libraryFormats: ['cjs', 'es'],
+	// Rename CSS chunk
+	assetFileNames: (chunkInfo) => chunkInfo.name.endsWith('.css') ? 'style.css' : undefined,
 	replace: {
 		__TRANSLATIONS__: `;${JSON.stringify(translations)}`,
 	},


### PR DESCRIPTION
`npm run build` works because it has a bash script in `npm` script to rename the CSS chunk: `&& mv dist/main.css dist/style.css`

But `npm run dev` and `npm run watch` make an invalid bundle without this `move`.

This PR removes this move on npm script and changes the CSS chunk name in Vite config.

To test try to build server with dev build of this lib.