### PR TITLE
enh: Migrate to NcDialog

### DIFF
--- a/l10n/messages.pot
+++ b/l10n/messages.pot
@@ -2,6 +2,9 @@ msgid ""
 msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 
+msgid "Checking password …"
+msgstr ""
+
 msgid "Confirm"
 msgstr ""
 
@@ -9,6 +12,9 @@ msgid "Confirm your password"
 msgstr ""
 
 msgid "Password"
+msgstr ""
+
+msgid "Please enter your password"
 msgstr ""
 
 msgid "This action needs authentication"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/gettext-parser": "^4.0.4",
         "@types/node": "^20.11.5",
         "@types/node-gettext": "^3.0.6",
+        "@vue/tsconfig": "^0.5.1",
         "gettext-extractor": "^3.8.0",
         "gettext-parser": "^7.0.1",
         "sass": "^1.70.0",
@@ -3693,6 +3694,12 @@
       "version": "3.4.15",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.15.tgz",
       "integrity": "sha512-KzfPTxVaWfB+eGcGdbSf4CWdaXcGDqckoeXUh7SB3fZdEtzPCK2Vq9B/lRRL3yutax/LWITz+SwvgyOxz5V75g==",
+      "dev": true
+    },
+    "node_modules/@vue/tsconfig": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
+      "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true
     },
     "node_modules/@vueuse/components": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/gettext-parser": "^4.0.4",
     "@types/node": "^20.11.5",
     "@types/node-gettext": "^3.0.6",
+    "@vue/tsconfig": "^0.5.1",
     "gettext-extractor": "^3.8.0",
     "gettext-parser": "^7.0.1",
     "sass": "^1.70.0",

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="vite/client" />
-
-declare module '*.vue' {
-	import Vue from 'vue'
-	export default Vue
-}

--- a/src/vue-shims.d.ts
+++ b/src/vue-shims.d.ts
@@ -1,0 +1,9 @@
+declare module '*.vue' {
+	import Vue from 'vue'
+	export default Vue
+}
+
+declare module '@nextcloud/vue/dist/Components/*.js' {
+	import Vue from 'vue'
+	export default Vue
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,13 @@
 {
+  "extends": "@vue/tsconfig",
   "compilerOptions": {
-    "target": "esnext",
-    "useDefineForClassFields": true,
-    "module": "esnext",
-    "moduleResolution": "bundler",
     "strict": true,
-    "jsx": "preserve",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    "isolatedModules": true,
-    "esModuleInterop": true,
-    "lib": ["esnext", "dom"],
-    "skipLibCheck": true,
-    "noImplicitAny": false, // Allow implicit any to fix type check errors of some dependencies on build
-    "noEmit": true,
-    "types": [
-      "vite/client",
-    ],
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.tsx", "src/**/*.vue"],
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.vue"
+  ],
   "references": [{ "path": "./tsconfig.node.json" }],
 }


### PR DESCRIPTION
* This requires #693 first!

Use NcDialog instead of NcModal, so we can reduce the boilerplate code (styles etc).

### Screenshots
*sorry forgot to switch to English language*

before | after
---|---
![image](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/assets/1855448/339bd985-3b77-444b-9a29-b171b9173804)|![image](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/assets/1855448/98eeb0b8-7c4b-4d70-ab0e-6d419927ef58)
