### PR TITLE
enh: Compress translations to reduce bundle size

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,11 +1,11 @@
-import type { GetTextTranslations } from 'gettext-parser'
+declare global {
+	interface Window {
+		nc_pageLoad: number
+		nc_lastLogin: number
+		backendAllowsPasswordConfirmation: boolean
+	}
 
-export declare global {
-  interface Window {
-    nc_pageLoad: number
-    nc_lastLogin: number
-    backendAllowsPasswordConfirmation: boolean
-  }
-
-  const __TRANSLATIONS__: Array<{ locale: string, json: GetTextTranslations }>
+	const __TRANSLATIONS__: Array<{ locale: string, translations: { msgid: string, msgid_plural?: string, msgstr: string }[] }>
 }
+
+export {}

--- a/src/utils/l10n.ts
+++ b/src/utils/l10n.ts
@@ -4,7 +4,11 @@ const gtBuilder = getGettextBuilder()
 	.detectLocale()
 
 __TRANSLATIONS__
-	.map(({ locale, json }) => gtBuilder.addTranslation(locale, json))
+	.map(({ locale, translations }) => gtBuilder.addTranslation(locale, {
+		translations: {
+			'': Object.fromEntries(translations.map((t) => [t.msgid, t])),
+		},
+	}))
 
 const gt = gtBuilder.build()
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,16 @@ const translations = fs
 		const po = fs.readFileSync(path)
 		const json = poParser.parse(po)
 
-		return { locale, json }
+		// Compress translations by removing everything not needed
+		const translations = Object.values(json.translations[''])
+			.filter((value) => value.msgid !== '')
+			.map((value) => ({
+				msgid: value.msgid,
+				msgid_plural: value.msgid_plural,
+				msgstr: value.msgstr,
+			}))
+
+		return { locale, translations }
 	})
 
 export default createLibConfig({
@@ -21,7 +30,7 @@ export default createLibConfig({
 }, {
 	libraryFormats: ['cjs', 'es'],
 	// Rename CSS chunk
-	assetFileNames: (chunkInfo) => chunkInfo.name.endsWith('.css') ? 'style.css' : undefined,
+	assetFileNames: (chunkInfo) => chunkInfo.name?.endsWith('.css') ? 'style.css' : undefined,
 	replace: {
 		__TRANSLATIONS__: `;${JSON.stringify(translations)}`,
 	},


### PR DESCRIPTION
This reduces the bundle size from ~36KiB to ~17KiB. This parts can not be treeshaken so this will fully affect apps, meaning each app will shrink by ~19KiB.