### PR TITLE
fix: Correctly export Typescript types in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/style.css",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },


### PR DESCRIPTION
- [x] chained onto #794 


Export the types instead of the faulty export the styles as the types :eyes: 