### PR TITLE
chore: Prepare release of 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.1.1 - 2024-06-25
+[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/compare/v5.1.0...v5.1.1)
+
+### Fixed
+* fix: Correctly export Typescript types in `exports` [\#795](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/795)
+
+### Changed
+* Updated translations
+* chore(deps): Bump @nextcloud/router to 3.0.1
+* chore(deps): Bump @nextcloud/axios to 2.5.0
+* chore(deps): Bump @nextcloud/l10n to 3.1.0
+* chore(dev-deps): Update development dependencies [\#794](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/794)
+* chore: Update workflows from organization [\#797](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/797)
+
 ## 5.1.0 - 2024-03-22
 **Full Changelog**: https://github.com/nextcloud-libraries/nextcloud-password-confirmation/compare/v5.0.1...v5.1.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/password-confirmation",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/password-confirmation",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MIT",
       "dependencies": {
         "@nextcloud/axios": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/password-confirmation",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Password confirmation for Nextcloud",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## 5.1.1 - 2024-06-25
[Full Changelog](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/compare/v5.1.0...v5.1.1)

### Fixed
* fix: Correctly export Typescript types in `exports` [\#795](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/795)

### Changed
* Updated translations
* chore(deps): Bump @nextcloud/router to 3.0.1
* chore(deps): Bump @nextcloud/axios to 2.5.0
* chore(deps): Bump @nextcloud/l10n to 3.1.0
* chore(dev-deps): Update development dependencies [\#794](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/794)
* chore: Update workflows from organization [\#797](https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/797)