### PR TITLE
chore: move vue dependencies to plain dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
     time: "03:00"
     timezone: Europe/Paris
   versioning-strategy: increase
-  open-pull-requests-limit: 
+  open-pull-requests-limit: 10
   ignore:
     # no major updates on stable branches
     - dependency-name: "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project will be documented in this file.
  - SPDX-License-Identifier: MIT
  -->
 
+## 6.0.0 - UNRELEASED
+### Notes
+
+This package now builds on top of `@nextcloud/vue` version 9 using Vue 3.
+While this package uses Vue 3 it is also possible to use it within a Vue 2 project,
+in this case the Vue dependency will not be shared as the dependency was moved from a peer dependency to a plain dependency.
+This also means that if you are using Vue 2 you have to ensure you do not use bundler
+configurations that enforce resolving Vue to the same version as this will fail now,
+instead let the bundler choose the matching Vue version.
+
+For example if using Webpack this will no longer work in **Vue 2** apps:
+```js
+  resolve: {
+                alias: {
+                        vue$: path.resolve('./node_modules/vue'),
+                },
+  }
+```
+
+For Vue 3 apps nothing changed, meaning the app and this library will share the same Vue dependency as long as the versions are compatible.
+
+### Breaking
+
+* This package now uses Vue 3 internally.
+
 ## 5.3.1 - 2024-12-16
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@ This library exports a function that displays a password confirmation dialog whe
 
 | `@nextcloud/password-confirmation` | Maintained | Nextcloud   | `@nextcloud/vue` |
 | ---------------------------------- | ---------- | ----------- | ---------------- |
-| 6.x                                | ✅         | 30+         | 9.x (Vue 3)      |
+| 6.x                                | ✅         | 30+         | *9.x (Vue 3)* ¹  |
 | 5.x                                | ✅         | 28-31       | 8.x              |
 | 2.x - 4.x                          | ❌         | 25-27       | 7.x              |
 | 1.x                                | ❌         | < 25        | -                |
+
+¹: In version 6.x the `@nextcloud/vue` dependency is moved to `dependencies` so you can also use this library
+with an old version of `@nextcloud/vue` in your app dependencies if your app still uses Vue 2.
+Note that this might increase the bundled app size.
+If your app also already uses `@nextcloud/vue` version 9.x and Vue 3 then the bundle size will not increase.
 
 ## Installation
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@nextcloud/auth": "^2.4.0",
-        "@nextcloud/axios": "^2.5.0",
-        "@nextcloud/l10n": "^3.1.0",
-        "@nextcloud/router": "^3.0.1"
+        "@nextcloud/axios": "^2.5.1",
+        "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/router": "^3.0.1",
+        "@nextcloud/vue": "^9.0.0-rc.0",
+        "vue": "^3.5.13"
       },
       "devDependencies": {
         "@nextcloud/browserslist-config": "^3.0.1",
@@ -20,21 +22,16 @@
         "@nextcloud/vite-config": "^2.3.2",
         "@types/gettext-parser": "^8.0.0",
         "@types/node": "^22.10.2",
-        "@types/node-gettext": "^3.0.6",
         "@vue/tsconfig": "^0.7.0",
         "gettext-extractor": "^3.8.0",
         "gettext-parser": "^8.0.0",
-        "sass": "^1.77.6",
+        "sass": "^1.87.0",
         "typescript": "^5.4.3",
-        "vite": "^6.2.6"
+        "vite": "^6.3.5"
       },
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
-      },
-      "peerDependencies": {
-        "@nextcloud/vue": "^9.0.0-rc.0",
-        "vue": "^3.5.13"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -75,7 +72,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
       "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -98,7 +94,6 @@
       "resolved": "https://registry.npmjs.org/@ckpack/vue-color/-/vue-color-1.6.0.tgz",
       "integrity": "sha512-b9kFTKhYbNArfgP1lmnaVm0VNsWdZjqIbyHUYry7mZ+E7JeTQclbjq1+2xWn0SE3wzqRYlXmAVjECPOgteWmMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.6.0",
         "material-colors": "^1.2.6"
@@ -115,7 +110,6 @@
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -803,7 +797,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
       "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.9"
       }
@@ -813,7 +806,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
       "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.0",
         "@floating-ui/utils": "^0.2.9"
@@ -823,8 +815,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1129,7 +1120,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/capabilities/-/capabilities-1.2.0.tgz",
       "integrity": "sha512-L1NQtOfHWzkfj0Ple1MEJt6HmOHWAi3y4qs+OnwSWexqJT0DtXTVPyRxi7ADyITwRxS5H9R/HMl6USAj4Nr1nQ==",
       "license": "GPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "@nextcloud/initial-state": "^2.1.0"
       },
@@ -1182,7 +1172,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/initial-state/-/initial-state-2.2.0.tgz",
       "integrity": "sha512-cDW98L5KGGgpS8pzd+05304/p80cyu8U2xSDQGa+kGPTpUFmCbv2qnO5WrwwGTauyjYijCal2bmw82VddSH+Pg==",
       "license": "GPL-3.0-or-later",
-      "peer": true,
       "engines": {
         "node": "^20.0.0",
         "npm": "^10.0.0"
@@ -1211,7 +1200,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-3.0.2.tgz",
       "integrity": "sha512-wByt0R0/6QC44RBpaJr1MWghjjOxk/pRbACHo/ZWWKht1qYbJRHB4GtEi+35KEIHY07ZpqxiDk6dIRuN7sXYWQ==",
       "license": "GPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "@nextcloud/auth": "^2.3.0"
       },
@@ -1238,7 +1226,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/sharing/-/sharing-0.2.4.tgz",
       "integrity": "sha512-kOLAr0w4NDUGPF42L22i9iSs6Z3ylTsE0RudAGDBzw/pnxGY8PEwZI2j0IMAFRfQ7XFNcpV/EVHI5YCMxtxGMQ==",
       "license": "GPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "@nextcloud/initial-state": "^2.2.0"
       },
@@ -1252,7 +1239,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/timezones/-/timezones-0.2.0.tgz",
       "integrity": "sha512-1mwQ+asTFOgv9rxPoAMEbDF8JfnenIa2EGNS+8MATCyi6WXxYh0Lhkaq1d3l2+xNbUPHgMnk4cRYsvIo319lkA==",
       "license": "AGPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "ical.js": "^2.1.0"
       },
@@ -1308,7 +1294,6 @@
       "resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-9.0.0-rc.0.tgz",
       "integrity": "sha512-0elTkjnyiEDAWM/4acDhMbwVALcow5eHjzGF39RXwAIhjfMsMWhtCExVKaA2NR2/C1r7moDlKwH23BCGthQhLA==",
       "license": "AGPL-3.0-or-later",
-      "peer": true,
       "dependencies": {
         "@ckpack/vue-color": "^1.6.0",
         "@floating-ui/dom": "^1.6.13",
@@ -2235,7 +2220,6 @@
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -2298,7 +2282,6 @@
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
       "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -2324,7 +2307,6 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -2340,8 +2322,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.15.17",
@@ -2352,13 +2333,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/node-gettext": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/node-gettext/-/node-gettext-3.0.6.tgz",
-      "integrity": "sha512-A0W1IyyW3Ya+Wj6fDDWWwnXWNgrDNvKkq6xKj5Korc7YIo9023LP8qVTzgwQ5SUIANg2Pm2ggA7bfTcwoPPDUQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/parse5": {
       "version": "5.0.3",
@@ -2401,15 +2375,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
       "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.32.0",
@@ -2595,8 +2567,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.3",
@@ -2669,7 +2640,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.13.tgz",
       "integrity": "sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.25.3",
         "@vue/compiler-core": "3.5.13",
@@ -2687,7 +2657,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.13.tgz",
       "integrity": "sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2708,8 +2677,7 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@vue/language-core": {
       "version": "2.2.0",
@@ -2741,7 +2709,6 @@
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.13.tgz",
       "integrity": "sha512-NaCwtw8o48B9I6L1zl2p41OHo/2Z4wqYGGIK1Khu5T7yxrn+ATOixn/Udn2m+6kZKB/J7cuT9DbWWhRxqixACg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/shared": "3.5.13"
       }
@@ -2751,7 +2718,6 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.13.tgz",
       "integrity": "sha512-Fj4YRQ3Az0WTZw1sFe+QDb0aXCerigEpw418pw1HBUKFtnQHWzwojaukAs2X/c9DQz4MQ4bsXTGlcpGxU/RCIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2762,7 +2728,6 @@
       "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.13.tgz",
       "integrity": "sha512-dLaj94s93NYLqjLiyFzVs9X6dWhTdAlEAciC3Moq7gzAc13VJUdCnjjRurNM6uTLFATRHexHCTu/Xp3eW6yoog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.13",
         "@vue/runtime-core": "3.5.13",
@@ -2775,7 +2740,6 @@
       "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.13.tgz",
       "integrity": "sha512-wAi4IRJV/2SAW3htkTlB+dHeRmpTiVIK1OGLWV1yeStVSebSQQOwGwIq0D3ZIoBj2C2qpgz5+vX9iEBkTdk5YA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-ssr": "3.5.13",
         "@vue/shared": "3.5.13"
@@ -2814,7 +2778,6 @@
       "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.2.tgz",
       "integrity": "sha512-uHh78mVBXCEjam1uVfTzZ/HkyDwut/H6b2djSN9YTF+l/EA+XONfdCnOVSi1g+qVGSy65DcQAwyBNidAssnudQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "date-fns": "^4.1.0"
       },
@@ -2830,7 +2793,6 @@
       "resolved": "https://registry.npmjs.org/@vueuse/components/-/components-13.1.0.tgz",
       "integrity": "sha512-2cqRdRJ1CP/a9WpDAlIZneaivUuwze2e8W0CjKHbWqJ9p7nldccwMyEqKC7N6naYvipG469IGfYk6rnT/hoKfA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vueuse/core": "13.1.0",
         "@vueuse/shared": "13.1.0"
@@ -2844,7 +2806,6 @@
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.1.0.tgz",
       "integrity": "sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "13.1.0",
@@ -2862,7 +2823,6 @@
       "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.1.0.tgz",
       "integrity": "sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -2872,7 +2832,6 @@
       "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.1.0.tgz",
       "integrity": "sha512-IVS/qRRjhPTZ6C2/AM3jieqXACGwFZwWTdw5sNTSKk2m/ZpkuuN+ri+WCVUP8TqaKwJYt/KuMwmXspMAw8E6ew==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
@@ -3114,7 +3073,6 @@
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3152,8 +3110,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
       "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bn.js": {
       "version": "5.2.2",
@@ -3588,7 +3545,6 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3617,7 +3573,6 @@
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3628,7 +3583,6 @@
       "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
       "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3639,7 +3593,6 @@
       "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
       "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3650,7 +3603,6 @@
       "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
       "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -3712,7 +3664,6 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8"
       }
@@ -3756,7 +3707,6 @@
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
       "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -4049,15 +3999,13 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4075,7 +4023,6 @@
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
       "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -4105,7 +4052,6 @@
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
       "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "character-entities": "^2.0.0"
       },
@@ -4183,7 +4129,6 @@
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4241,7 +4186,6 @@
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.0"
       },
@@ -4348,7 +4292,6 @@
       "resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-15.0.4.tgz",
       "integrity": "sha512-OjuxqoMJRTTG7Vevz0mR1ZnqY1DI8gGnmoskuuC8qL8VwwTjrGdwAO4WRWtAUN8P6Di7kxvY6cUgNETNFmbP4A==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "core-js": "^3.23.5"
@@ -4776,7 +4719,6 @@
       "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
       "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -4824,8 +4766,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -4945,8 +4886,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5153,7 +5093,6 @@
       "resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-5.2.2.tgz",
       "integrity": "sha512-afW+h2CFafo+7Y9Lvw/xsqjaQlKLdJV7h1fCHfcYQ1C4SVMlu7OAekqWgu5d4SgvkBVU0pVpLlVsrSTBURFRkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "~1.1.1",
         "vue-resize": "^2.0.0-alpha.1"
@@ -5173,7 +5112,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.1.tgz",
       "integrity": "sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.1.0"
       }
@@ -5183,7 +5121,6 @@
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
       "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -5643,7 +5580,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
       "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -5657,7 +5593,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
       "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -5685,7 +5620,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
       "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/unist": "^3.0.0",
@@ -5702,7 +5636,6 @@
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
       "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
@@ -5726,7 +5659,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -5772,8 +5704,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.1.0.tgz",
       "integrity": "sha512-BOVfrH55xQ6kpS3muGvIXIg2l7p+eoe12/oS7R5yrO3TL/j/bLsR0PR+tYQESFbyTbvGgPHn9zQ6tI4FWyuSaQ==",
-      "license": "MPL-2.0",
-      "peer": true
+      "license": "MPL-2.0"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -5888,8 +5819,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5907,7 +5837,6 @@
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
       "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -5920,7 +5849,6 @@
       "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
       "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -5931,7 +5859,6 @@
       "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
       "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -5992,7 +5919,6 @@
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
       "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6045,7 +5971,6 @@
       "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
       "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6262,8 +6187,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.1.tgz",
       "integrity": "sha512-DRSlB9DKVW04c4SUdGvKK5FR6be45lTU9M76JnngqPeeGDqPwYc0zdUErtsNVMtxPXgUWV4HbXbnC4sNyBxkYg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/local-pkg": {
       "version": "1.1.1",
@@ -6319,7 +6243,6 @@
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -6330,7 +6253,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -6367,8 +6289,7 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -6396,7 +6317,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "escape-string-regexp": "^5.0.0",
@@ -6413,7 +6333,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6426,7 +6345,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
       "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -6451,7 +6369,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
       "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -6470,7 +6387,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
       "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -6495,7 +6411,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
       "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -6514,7 +6429,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
       "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-find-and-replace": "^3.0.0"
@@ -6529,7 +6443,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
@@ -6544,7 +6457,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
       "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -6566,7 +6478,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -6588,7 +6499,6 @@
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
@@ -6660,7 +6570,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -6696,7 +6605,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -6731,7 +6639,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -6753,7 +6660,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -6776,7 +6682,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -6797,7 +6702,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -6820,7 +6724,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
@@ -6843,7 +6746,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -6864,7 +6766,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -6884,7 +6785,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -6906,7 +6806,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -6927,7 +6826,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -6947,7 +6845,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^2.0.0",
@@ -6969,8 +6866,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
@@ -6986,8 +6882,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
@@ -7004,7 +6899,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
       }
@@ -7024,7 +6918,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-types": "^2.0.0"
       }
@@ -7044,7 +6937,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
@@ -7066,7 +6958,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
@@ -7088,8 +6979,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromark-util-types": {
       "version": "2.0.2",
@@ -7105,8 +6995,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -7585,7 +7474,6 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
       "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "p-timeout": "^6.1.2"
@@ -7602,7 +7490,6 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
       "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -7688,7 +7575,6 @@
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
       "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
@@ -7707,8 +7593,7 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/parse-imports-exports": {
       "version": "0.2.4",
@@ -7970,7 +7855,6 @@
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
       "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8177,7 +8061,6 @@
       "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
       "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@ungap/structured-clone": "^1.0.0",
@@ -8196,7 +8079,6 @@
       "resolved": "https://registry.npmjs.org/rehype-highlight/-/rehype-highlight-7.0.2.tgz",
       "integrity": "sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-text": "^4.0.0",
@@ -8214,7 +8096,6 @@
       "resolved": "https://registry.npmjs.org/rehype-react/-/rehype-react-8.0.0.tgz",
       "integrity": "sha512-vzo0YxYbB2HE+36+9HWXVdxNoNDubx63r5LBzpxBGVWM8s9mdnMdbmuJBAX6TTyuGdZjZix6qU3GcSuKCIWivw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
@@ -8230,7 +8111,6 @@
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
       "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-newline-to-break": "^2.0.0",
@@ -8246,7 +8126,6 @@
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -8263,7 +8142,6 @@
       "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
       "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -8808,7 +8686,6 @@
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
       "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -8918,7 +8795,6 @@
       "resolved": "https://registry.npmjs.org/splitpanes/-/splitpanes-4.0.3.tgz",
       "integrity": "sha512-S/f1CoH2JroOib7kzQtTQNtQCa7VzNQ2qKOO5HNj/5EVVcNkfz1eX/sH+X3XKdBdDLihEKDekVGwrLADd2oirA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/antoniandre"
       },
@@ -9044,7 +8920,6 @@
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
       "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -9071,8 +8946,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
       "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/strnum": {
       "version": "2.1.0",
@@ -9092,7 +8966,6 @@
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.16.tgz",
       "integrity": "sha512-/Q6ld50hKYPH3d/r6nr117TZkHR0w0kGGIVfpG9N6D8NymRPM9RqCUv4pRpJ62E5DqOYx2AFpbZMyCPnjQCnOw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "style-to-object": "1.0.8"
       }
@@ -9102,7 +8975,6 @@
       "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.8.tgz",
       "integrity": "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inline-style-parser": "0.2.4"
       }
@@ -9138,8 +9010,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
       "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/timers-browserify": {
       "version": "2.0.12",
@@ -9199,15 +9070,13 @@
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/tributejs/-/tributejs-5.1.3.tgz",
       "integrity": "sha512-B5CXihaVzXw+1UHhNFyAwUTMDk1EfoLP5Tj1VhD9yybZ1I8DZJEv8tZ1l0RJo0t0tk9ZhR8eG5tEsaCvRigmdQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -9218,7 +9087,6 @@
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -9329,7 +9197,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -9349,7 +9216,6 @@
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-4.0.0.tgz",
       "integrity": "sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -9363,7 +9229,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
       "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -9378,7 +9243,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -9392,7 +9256,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
       "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -9406,7 +9269,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
@@ -9420,7 +9282,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
       "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -9436,7 +9297,6 @@
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
       "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -9566,7 +9426,6 @@
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -9581,7 +9440,6 @@
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
       "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -9739,7 +9597,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.13.tgz",
       "integrity": "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.13",
         "@vue/compiler-sfc": "3.5.13",
@@ -9787,7 +9644,6 @@
       "resolved": "https://registry.npmjs.org/vue-resize/-/vue-resize-2.0.0-alpha.1.tgz",
       "integrity": "sha512-7+iqOueLU7uc9NrMfrzbG8hwMqchfVfSzpVlCMeJQe4pyibqyoifDNbKTZvwxZKDvGkB+PdFeKvnGZMoEb8esg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "vue": "^3.0.0"
       }
@@ -9797,7 +9653,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
       "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -9813,7 +9668,6 @@
       "resolved": "https://registry.npmjs.org/vue-select/-/vue-select-4.0.0-beta.6.tgz",
       "integrity": "sha512-K+zrNBSpwMPhAxYLTCl56gaMrWZGgayoWCLqe5rWwkB8aUbAUh7u6sXjIR7v4ckp2WKC7zEEUY27g6h1MRsIHw==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "vue": "3.x"
       }
@@ -9942,7 +9796,6 @@
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
   ],
   "dependencies": {
     "@nextcloud/auth": "^2.4.0",
-    "@nextcloud/axios": "^2.5.0",
-    "@nextcloud/l10n": "^3.1.0",
-    "@nextcloud/router": "^3.0.1"
+    "@nextcloud/axios": "^2.5.1",
+    "@nextcloud/l10n": "^3.2.0",
+    "@nextcloud/router": "^3.0.1",
+    "@nextcloud/vue": "^9.0.0-rc.0",
+    "vue": "^3.5.13"
   },
   "devDependencies": {
     "@nextcloud/browserslist-config": "^3.0.1",
@@ -52,17 +54,12 @@
     "@nextcloud/vite-config": "^2.3.2",
     "@types/gettext-parser": "^8.0.0",
     "@types/node": "^22.10.2",
-    "@types/node-gettext": "^3.0.6",
     "@vue/tsconfig": "^0.7.0",
     "gettext-extractor": "^3.8.0",
     "gettext-parser": "^8.0.0",
-    "sass": "^1.77.6",
+    "sass": "^1.87.0",
     "typescript": "^5.4.3",
-    "vite": "^6.2.6"
-  },
-  "peerDependencies": {
-    "@nextcloud/vue": "^9.0.0-rc.0",
-    "vue": "^3.5.13"
+    "vite": "^6.3.5"
   },
   "engines": {
     "node": "^20.0.0",


### PR DESCRIPTION
* similar to how it is done on nextcloud-dialogs
* closes https://github.com/nextcloud-libraries/nextcloud-password-confirmation/pull/915

This allows in theory (tested) to also use this library with Vue 2 apps. For those the bundle size will increase as Vue needs to bundled two times, but if you use Vue 3 all works as intended (only bundled once so small asset size).

This allows us to drop maintenance on v5 as soon as Nextcloud 31 gets EOL.