### PR TITLE
chore!: drop legacy style entry point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ For Vue 3 apps nothing changed, meaning the app and this library will share the 
 ### Breaking
 
 * This package now uses Vue 3 internally.
+* The legacy, deprecated, `dist/style.css` entry point was removed. If you still use it please adjust as following:
+```diff
+- import '@nextcloud/password-confirmation/dist/style.css'
++ import '@nextcloud/password-confirmation/style.css'
+```
 
 ## 5.3.1 - 2024-12-16
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
-    "./style.css": "./dist/style.css",
-    "./dist/style.css": "./dist/style.css"
+    "./style.css": "./dist/style.css"
   },
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
simplify the entry points by only allow one way of importing the styles.