### PR TITLE
chore: migrate to nextcloud-logger to respect logging level

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,13 +5,4 @@
 
 import { recommendedLibrary } from '@nextcloud/eslint-config'
 
-export default [
-	...recommendedLibrary,
-
-	{
-		rules: {
-			// TODO: migrate to nextcloud-logger to respect defined logging level
-			'no-console': 'warn',
-		},
-	},
-]
+export default [...recommendedLibrary]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nextcloud/auth": "^2.4.0",
         "@nextcloud/axios": "^2.5.1",
         "@nextcloud/l10n": "^3.2.0",
+        "@nextcloud/logger": "^3.0.2",
         "@nextcloud/router": "^3.0.1",
         "@nextcloud/vue": "^9.0.0-rc.0",
         "vue": "^3.5.13"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@nextcloud/auth": "^2.4.0",
     "@nextcloud/axios": "^2.5.1",
     "@nextcloud/l10n": "^3.2.0",
+    "@nextcloud/logger": "^3.0.2",
     "@nextcloud/router": "^3.0.1",
     "@nextcloud/vue": "^9.0.0-rc.0",
     "vue": "^3.5.13"

--- a/src/components/PasswordDialog.vue
+++ b/src/components/PasswordDialog.vue
@@ -39,6 +39,7 @@ import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
 import NcPasswordField from '@nextcloud/vue/components/NcPasswordField'
 import { t } from '../utils/l10n.js'
+import { logger } from '../utils/logger.js'
 
 type ICanFocus = {
 	focus: () => void
@@ -107,7 +108,7 @@ export default defineComponent({
 				await this.validate(this.password)
 				this.$emit('close', true)
 			} catch (error) {
-				console.debug('Exception during password confirmation', { error })
+				logger.debug('Exception during password confirmation', { error })
 				this.showError = true
 				this.selectPasswordField()
 			} finally {

--- a/src/password-confirmation.ts
+++ b/src/password-confirmation.ts
@@ -12,6 +12,7 @@ import { spawnDialog } from '@nextcloud/vue/functions/dialog'
 import PasswordDialogVue from './components/PasswordDialog.vue'
 import { PwdConfirmationMode } from './globals.ts'
 import { isPasswordConfirmationRequired } from './is-required.ts'
+import { logger } from './utils/logger.ts'
 
 let INTERCEPTOR_INITIALIZED = false
 
@@ -37,13 +38,13 @@ export const confirmPassword = async (): Promise<void> => {
  * @param password - Password to be confirmed
  */
 async function _confirmPassword(password: string) {
-	console.debug('Confirming password')
+	logger.debug('Confirming password')
 
 	const url = generateUrl('/login/confirm')
 	const { data } = await axios.post(url, { password })
 	window.nc_lastLogin = data.lastLogin
 
-	console.debug('Password confirmed')
+	logger.debug('Password confirmed')
 }
 
 /**
@@ -91,7 +92,7 @@ export function addPasswordConfirmationInterceptors(axios: AxiosInstance): void 
 					return Promise.resolve()
 				}
 				case PwdConfirmationMode.Strict:
-					console.debug('Adding auth info to the request', { config })
+					logger.debug('Adding auth info to the request', { config })
 					config.auth = {
 						username: getCurrentUser()?.uid ?? '',
 						password,
@@ -112,7 +113,7 @@ export function addPasswordConfirmationInterceptors(axios: AxiosInstance): void 
 				return response
 			}
 
-			console.debug('Password confirmation succeeded', { response })
+			logger.debug('Password confirmation succeeded', { response })
 			window.nc_lastLogin = Date.now() / 1000
 			validatePromise.resolve()
 
@@ -123,7 +124,7 @@ export function addPasswordConfirmationInterceptors(axios: AxiosInstance): void 
 				throw error
 			}
 
-			console.debug('Password confirmation failed', { error })
+			logger.debug('Password confirmation failed', { error })
 			validatePromise.reject(error)
 
 			if (!(error.response?.status === 403 && error.response.data.message === 'Password confirmation is required')) {
@@ -132,7 +133,7 @@ export function addPasswordConfirmationInterceptors(axios: AxiosInstance): void 
 
 			// If the password confirmation failed, we trigger another request.
 			// that will go through the password confirmation flow again.
-			console.debug('Triggering new request', { error })
+			logger.debug('Triggering new request', { error })
 			return axios.request(error.config)
 		},
 	)

--- a/src/utils/logger.spec.ts
+++ b/src/utils/logger.spec.ts
@@ -1,0 +1,17 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+import { expect, test, vi } from 'vitest'
+import { logger } from './logger.ts'
+
+// we only need to test the app is correct - the rest is part of the logger library
+test('logger', () => {
+	const spy = vi.spyOn(console, 'warn')
+	spy.mockImplementation(() => {})
+
+	logger.warn('test')
+	expect(spy).toBeCalled()
+	expect(spy.mock.calls[0][1]).toHaveProperty('app', '@nextcloud/password-confirmation')
+})

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,11 @@
+/*!
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: CC0-1.0
+ */
+
+import { getLoggerBuilder } from '@nextcloud/logger'
+
+export const logger = getLoggerBuilder()
+	.setApp('@nextcloud/password-confirmation')
+	.detectLogLevel()
+	.build()


### PR DESCRIPTION
If the admin configured the frontend to not display debug messages we should respect that. So instead of console we should use the logger for all messages.