### PR TITLE
chore: drop unneeded TS declarations

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -18,7 +18,7 @@ SPDX-FileCopyrightText = "2020-2024 Nextcloud translators"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
-path = ["tsconfig.json", "tsconfig.node.json", "typedoc.json"]
+path = ["tsconfig.json", "tsconfig.node.json", "tsconfig.typedoc.json", "typedoc.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2022-2024 Nextcloud GmbH and Nextcloud contributors"
 SPDX-License-Identifier = "CC0-1.0"

--- a/build/typedoc-shims.d.ts
+++ b/build/typedoc-shims.d.ts
@@ -1,0 +1,20 @@
+/*!
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: MIT
+ */
+
+/* eslint-disable @typescript-eslint/no-empty-object-type */
+declare module '*/PasswordDialog.vue' {
+	import type { ComponentOptionsMixin, ComponentProvideOptions, DefineComponent, PublicProps } from 'vue'
+
+	type DialogProps = {
+		validate: (value: string) => Promise<void> | void
+	}
+
+	const component: DefineComponent<DialogProps, {}, {}, {}, {}, ComponentOptionsMixin, ComponentOptionsMixin, {
+		close: (a: boolean) => void
+	}, string, PublicProps, Readonly<DialogProps> & Readonly<{
+		onClose?: ((a: boolean) => void) | undefined
+	}>, {}, {}, {}, {}, string, ComponentProvideOptions, false>
+	export default component
+}

--- a/src/vue-shims.d.ts
+++ b/src/vue-shims.d.ts
@@ -3,12 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-declare module '*.vue' {
-	import Vue from 'vue'
-	export default Vue
-}
+declare module '@nextcloud/vue/components/NcPasswordField' {
+	import type { Component } from 'vue'
+	const component: Component
 
-declare module '@nextcloud/vue/components/*' {
-	import Vue from 'vue'
-	export default Vue
+	export default component
 }

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"include": [
+		"build/*.d.ts",
+		"src/**.ts",
+		"src/**.vue"
+	]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -5,5 +5,6 @@
     "githubPages": true,
     "navigationLinks": {
         "GitHub": "https://github.com/nextcloud-libraries/nextcloud-password-confirmation"
-    }
+    },
+    "tsconfig": "./tsconfig.typedoc.json"
 }


### PR DESCRIPTION
All vue modules used are declared already, so we only need to mock it for NcPasswordField as this is not yet migrated to Typescript.