### PR TITLE
chore: allow Typescript to import paths with .ts extension

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "@vue/tsconfig",
   "compilerOptions": {
-    "strict": true,
+    "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "strict": true,
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
This is best practice nowadays as we use a bundler anyways.